### PR TITLE
Updated the end message pattern and the readme for changes in webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The following example shows how to add problem matchers to your project:
 }
 ```
 
-👉 In order for **\$ts-webpack-watch**, **\$ts-checker-webpack-watch**, **\$ts-checker-eslint-webpack-watch**, and **\$tslint-webpack-watch** to work properly, you must add `--info-verbosity verbose` to your webpack watch command e.g. `webpack --watch --info-verbosity verbose` as this instructs webpack to output lifecycle event messages for each re-compile
+👉 In order for **\$ts-webpack-watch**, **\$ts-checker-webpack-watch**, **\$ts-checker-eslint-webpack-watch**, and **\$tslint-webpack-watch** to work properly in webpack version 4, you must add `--info-verbosity verbose` to your webpack watch command e.g. `webpack --watch --info-verbosity verbose` as this instructs webpack to output lifecycle event messages for each re-compile.  (This is not needed in webpack version 5 and webpack version 5 does not support the --info-verbosity command line option.)
 
 👉 In order for **\$ts-checker5-webpack**, **\$ts-checker5-webpack-watch**, **\$ts-checker5-eslint-webpack**, and **\$ts-checker5-eslint-webpack-watch** to work properly, you must set `formatter: 'basic'` in your [fork-ts-checker-webpack-plugin options](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/alpha#options) and add `--info-verbosity verbose` to your webpack watch command e.g. `webpack --watch --info-verbosity verbose` as this instructs webpack to output lifecycle event messages for each re-compile
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 						"regexp": "Compiling.*?|Compilation .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "Compiled .*?successfully|Compilation .*?finished"
+						"regexp": "Compiled .*?successfully|Compilation .*?finished|webpack .* compiled with.* in "
 					}
 				}
 			},
@@ -106,7 +106,7 @@
 						"regexp": "Compiling.*?|Compilation .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "Compiled .*?successfully|Compilation .*?finished"
+						"regexp": "Compiled .*?successfully|Compilation .*?finished|webpack .* compiled with.* in "
 					}
 				}
 			},
@@ -145,7 +145,7 @@
 						"regexp": "Compiling.*?|Compilation .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "Compiled .*?successfully|Compilation .*?finished"
+						"regexp": "Compiled .*?successfully|Compilation .*?finished|webpack .* compiled with.* in "
 					}
 				}
 			},


### PR DESCRIPTION
Webpack 5.11 ends unsuccessful compiles with:

ERROR in E:\repos\electron-template\src\renderer\renderer.tsx
./src/renderer/renderer.tsx
[tsl] ERROR in E:\repos\electron-template\src\renderer\renderer.tsx(9,3)
      TS2304: Cannot find name '#'.

**webpack 5.11.0 compiled with 6 errors in 3860 ms**


It also doesn't support the --info-verbosity flag that the readme suggests is crucial.  (Fortunately, it seems not to be needed anymore).