### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,13 @@ The following example shows how to add problem matchers to your project:
 }
 ```
 
-### Webpack v5 (webpack-cli@4)
+### webpack-cli@4
 
-👉 Using Webpack v5 or later: In order for the _watch_ matchers to work properly in Webpack v4, you must add `--info-verbosity verbose` to your webpack watch command e.g. `webpack --watch --info-verbosity verbose` as this instructs webpack to output lifecycle event messages for each re-compile.
-
-### Webpack v4 (webpack-cli@3)
-
-n order for the _watch_ matchers to work properly, you must add `infrastructureLogging: { level: "log" }` to your `webpack.config.js` as this instructs webpack to output lifecycle event messages for each re-compile.
-
-For example:
+In order for the _watch_ matchers to work properly, you must add `infrastructureLogging: { level: "log" }` to your `webpack.config.js` as this instructs webpack to output lifecycle event messages for each re-compile. E.g.:
 
 ```js
 // webpack.config.js
+
 module.exports = {
 	// ...the webpack configuration
 	infrastructureLogging: {
@@ -59,6 +54,14 @@ module.exports = {
 	},
 };
 ```
+
+**Note:** versions of webpack-cli lower than 4.3 are not supported, as they do not support the `infrastructureLogging` configuration.
+
+### webpack-cli@3
+
+In order for the _watch_ matchers to work properly, you must add `--info-verbosity verbose` to your `webpack --watch` command e.g. `webpack --watch --info-verbosity verbose` as this instructs webpack to output lifecycle event messages for each re-compile.
+
+## ts-checker
 
 👉 In addition, when using the **\$ts-checker-webpack**, **\$ts-checker-webpack-watch**, **\$ts-checker-eslint-webpack**, and **\$ts-checker-eslint-webpack-watch** matchers, you must also set `formatter: 'basic'` in your [fork-ts-checker-webpack-plugin options](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/tree/alpha#options)
 


### PR DESCRIPTION
`--info-verbosity` is only available in webpack-cli v3, while infrastructure logging is only available in webpack-cli v4 (4.3+). The version of webpack does not matter. I tried webpack-cli v4 with webpack v4, and also webpack-cli v3 with webpack v5.