### PR TITLE
fix: watcher completing if compiled with warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 						"regexp": "[Cc]ompiling.*?|[Cc]ompil(ation|er) .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "[Cc]ompiled (.*?successfully|with .*?error)|[Cc]ompil(ation|er) .*?finished"
+						"regexp": "[Cc]ompiled (.*?successfully|with .*?(error|warning))|[Cc]ompil(ation|er) .*?finished"
 					}
 				}
 			},
@@ -113,7 +113,7 @@
 						"regexp": "[Cc]ompiling.*?|[Cc]ompil(ation|er) .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "[Cc]ompiled (.*?successfully|with .*?error)|[Cc]ompil(ation|er) .*?finished"
+						"regexp": "[Cc]ompiled (.*?successfully|with .*?(error|warning))|[Cc]ompil(ation|er) .*?finished"
 					}
 				}
 			},
@@ -159,7 +159,7 @@
 						"regexp": "[Cc]ompiling.*?|[Cc]ompil(ation|er) .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "[Cc]ompiled (.*?successfully|with .*?error)|[Cc]ompil(ation|er) .*?finished"
+						"regexp": "[Cc]ompiled (.*?successfully|with .*?(error|warning))|[Cc]ompil(ation|er) .*?finished"
 					}
 				}
 			},
@@ -206,7 +206,7 @@
 						"regexp": "[Cc]ompiling.*?|[Cc]ompil(ation|er) .*?starting"
 					},
 					"endsPattern": {
-						"regexp": "[Cc]ompiled (.*?successfully|with .*?error)|[Cc]ompil(ation|er) .*?finished"
+						"regexp": "[Cc]ompiled (.*?successfully|with .*?(error|warning))|[Cc]ompil(ation|er) .*?finished"
 					}
 				}
 			}


### PR DESCRIPTION
Webpack can compile with a warning:

```
> vscode-selfhost-test-provider@0.3.7 watch
> webpack --watch --config ./build/node-extension.webpack.config.js

asset extension.js 9.57 MiB [compared for emit] (name: main) 1 related asset
asset mappings.wasm 47.6 KiB [compared for emit] [from: node_modules/source-map/lib/mappings.wasm] [copied]
runtime modules 1.04 KiB 5 modules
modules by path ./ 9.55 MiB
  modules by path ./node_modules/ 9.51 MiB
    modules by path ./node_modules/source-map/ 99.9 KiB 12 modules
    modules by path ./node_modules/source-map-support/ 119 KiB 12 modules
    modules by path ./node_modules/typescript/lib/ 9.28 MiB
      ./node_modules/typescript/lib/typescript.js 9.28 MiB [built] [code generated]
      ./node_modules/typescript/lib/ sync 160 bytes [optional] [built] [code generated]
    4 modules
  modules by path ./src/*.ts 37 KiB 8 modules
13 modules

WARNING in ./node_modules/typescript/lib/typescript.js 3725:20-42
Critical dependency: the request of a dependency is an expression
 @ ./src/failingDeepStrictEqualAssertFixer.ts 4:0-33 51:18-34 51:46-69 56:16-35 56:70-89 59:21-33 61:38-61 62:16-38 64:18-53 64:54-81 65:18-35 66:19-31 69:31-53 72:46-65 72:76-95 105:13-32
 @ ./src/extension.ts 5:0-88 64:180-213

WARNING in ./node_modules/typescript/lib/typescript.js 7546:41-60
Critical dependency: the request of a dependency is an expression
 @ ./src/failingDeepStrictEqualAssertFixer.ts 4:0-33 51:18-34 51:46-69 56:16-35 56:70-89 59:21-33 61:38-61 62:16-38 64:18-53 64:54-81 65:18-35 66:19-31 69:31-53 72:46-65 72:76-95 105:13-32
 @ ./src/extension.ts 5:0-88 64:180-213

2 warnings have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.59.0 compiled with 2 warnings in 3213 ms
```

This was not being detected by the matchers